### PR TITLE
Remove decimal point from example carrier response.

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Example response:
            {
                'service_name': 'canadapost-overnight',
                'service_code': 'ON',
-               'total_price': '12.95',
+               'total_price': '1295',
                'currency': 'CAD',
                'min_delivery_date': '2013-04-12 14:48:45 -0400',
                'max_delivery_date': '2013-04-12 14:48:45 -0400'
@@ -204,7 +204,7 @@ Example response:
            {
                'service_name': 'fedex-2dayground',
                'service_code': '1D',
-               'total_price': '29.34',
+               'total_price': '2934',
                'currency': 'USD',
                'min_delivery_date': '2013-04-12 14:48:45 -0400',
                'max_delivery_date': '2013-04-12 14:48:45 -0400'
@@ -212,7 +212,7 @@ Example response:
            {
                'service_name': 'fedex-2dayground',
                'service_code': '1D',
-               'total_price': '29.34',
+               'total_price': '2934',
                'currency': 'USD',
                'min_delivery_date': '2013-04-12 14:48:45 -0400',
                'max_delivery_date': '2013-04-12 14:48:45 -0400'


### PR DESCRIPTION
This tripped me up today. The docs on the Shopify site are correct, but I was just basing my expected response from the example response here.